### PR TITLE
Add place to feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ local_settings.py
 .coverage
 htmlcov
 .cache
+.pytest_cache/
 perf*csv
 /*hack*py
 *.egg-info

--- a/feedback/twitter.py
+++ b/feedback/twitter.py
@@ -212,12 +212,22 @@ class TwitterHandler:
         name = TwitterHandler._parse_name(tweet.user.name)
         ticket_dict['first_name'] = name[0]
         ticket_dict['last_name'] = name[1]
-        ticket_dict['description'] = '%s%s\n%s\n%s' % (
+        description = '%s%s\n%s\n%s' % (
             description_header,
             tweet.user.screen_name,
             tweet_text.replace(settings.SEARCH_STRING, ''),
             url
         )
+        if tweet.place:
+            place_name = 'Paikka: %s' % tweet.place.full_name
+            description = '%s%s\n%s\n%s\n%s' % (
+                description_header,
+                tweet.user.screen_name,
+                tweet_text.replace(settings.SEARCH_STRING, ''),
+                place_name,
+                url
+            )
+        ticket_dict['description'] = description
         ticket_dict['title'] = 'Twitter-palaute'
         if tweet.geo is not None:
             ticket_dict['lat'] = tweet.geo['coordinates'][0]


### PR DESCRIPTION
If tweet has a location added by the user, we can grab its name.
Twitter only allows specifiying cities or city neighborhoods
as locations, nothing more precise than that. At least ATM.

Closes #25 