### PR TITLE
Fix coordinates parsing from tweet object

### DIFF
--- a/feedback/twitter.py
+++ b/feedback/twitter.py
@@ -229,9 +229,9 @@ class TwitterHandler:
             )
         ticket_dict['description'] = description
         ticket_dict['title'] = 'Twitter-palaute'
-        if tweet.geo is not None:
-            ticket_dict['lat'] = tweet.geo['coordinates'][0]
-            ticket_dict['long'] = tweet.geo['coordinates'][1]
+        if tweet.coordinates is not None:
+            ticket_dict['lat'] = tweet.coordinates['coordinates'][1]
+            ticket_dict['long'] = tweet.coordinates['coordinates'][0]
         else:
             ticket_dict['lat'] = None
             ticket_dict['long'] = None


### PR DESCRIPTION
Tweet.geo is deprecated in favor of tweet.coordinates. Also, the
the first value is now longitude, followed by the latitude, while
previously it was the other way around.