### PR TITLE
Return empty list if fetching DMs fails

### DIFF
--- a/feedback/twitter.py
+++ b/feedback/twitter.py
@@ -171,6 +171,7 @@ class TwitterHandler:
             return self.twitter_api.direct_messages(since_id=latest_direct_message_id)
         except tweepy.error.TweepError as e:
             logger.error('Cannot fetch direct messages, exception: {}'.format(e))
+            return []
 
     def _fetch_single_tweet(self, status_id):
         try:


### PR DESCRIPTION
In order to avoid error later we need to return an empty list.