### PR TITLE
Custom Direct Messages API interactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+branches: {only: [master]}
 sudo: false
 dist: trusty
 
@@ -12,16 +13,23 @@ cache: pip
 addons:
   postgresql: 9.5
 
-install: 'pip install codecov -r requirements.txt -r requirements-dev.txt'
+install: 'pip install -r requirements.txt -r requirements-dev.txt'
 
 before_script:
   - psql -c 'create database palautebot;' -U postgres
 
 script:
-  - flake8
   - pytest -ra -vvv --cov
 
-after_success: codecov
+after_success: pip install codecov && codecov
 
 env:
-  - SECRET_KEY=topsecret123 DATABASE_URL="postgres://postgres:@localhost/palautebot"
+  - TEST_PART=tests SECRET_KEY=topsecret123 DATABASE_URL="postgres://postgres:@localhost/palautebot"
+
+matrix:
+  include:
+    - env: TEST_PART=style
+      install: pip install -r requirements.txt -r requirements-dev.txt
+      script:
+        - flake8
+        - isort -c

--- a/feedback/custom_tweepy_api.py
+++ b/feedback/custom_tweepy_api.py
@@ -1,0 +1,88 @@
+from datetime import datetime
+
+from tweepy import API
+from tweepy.binder import bind_api
+from tweepy.error import TweepError
+from tweepy.models import DirectMessage, ModelFactory
+from tweepy.parsers import JSONParser, ModelParser
+
+
+class CustomTweepyAPI(API):
+
+    @property
+    def direct_messages(self):
+        """ :reference: https://dev.twitter.com/rest/reference/get/direct_messages
+            :allowed_param:'since_id', 'max_id', 'count', 'full_text'
+        """
+        return bind_api(
+            api=self,
+            path='/direct_messages/events/list.json',
+            payload_type='direct_message', payload_list=True,
+            allowed_param=['count', 'cursor'],
+            require_auth=True
+        )
+
+
+class CustomDirectMessage(DirectMessage):
+
+    @classmethod
+    def parse(cls, api, json):
+        dm = cls(api)
+        for k, v in json.items():
+            if k == 'id':
+                setattr(dm, 'id_str', v)
+            elif k == 'created_timestamp':
+                setattr(dm, 'created_at', datetime.fromtimestamp(int(v) / 1000.0))
+            elif k == 'message_create':
+                message_object = v
+                for key, value in message_object.items():
+                    if key == 'target':
+                        setattr(dm, 'recipient', api.get_user(value['recipient_id']))
+                    elif key == 'sender_id':
+                        setattr(dm, 'sender', api.get_user(value))
+                    elif key == 'message_data':
+                        message_object = value
+                        for data_key, data_value in message_object.items():
+                            setattr(dm, data_key, data_value)
+                    else:
+                        setattr(dm, key, value)
+            else:
+                setattr(dm, k, v)
+        return dm
+
+
+class CustomModelFactory(ModelFactory):
+    direct_message = CustomDirectMessage
+
+
+class CustomModelParser(ModelParser):
+    def parse(self, method, payload):
+        try:
+            if method.payload_type is None:
+                return
+            model = getattr(self.model_factory, method.payload_type)
+        except AttributeError:
+            raise TweepError('No model for this payload type: '
+                             '%s' % method.payload_type)
+
+        json = JSONParser.parse(self, method, payload)
+        if isinstance(json, tuple):
+            json, cursors = json
+        else:
+            cursors = None
+
+        if method.payload_list:
+            if 'events' in json:
+                result = model.parse_list(method.api, json['events'])
+            else:
+                result = model.parse_list(method.api, json)
+        else:
+            result = model.parse(method.api, json)
+
+        if cursors:
+            return result, cursors
+        else:
+            return result
+
+
+custom_parser = CustomModelParser(model_factory=CustomModelFactory)

--- a/feedback/tests/data/direct_message_json.py
+++ b/feedback/tests/data/direct_message_json.py
@@ -93,3 +93,43 @@ test_direct_message_json = """{
     "sender_screen_name": "theSeanCook",
     "text": "https://twitter.com/fooman/status/98765"
 }"""
+
+new_direct_message_api_response = """{
+    "events": [
+        {
+            "type": "message_create",
+            "id": "12345678987654321",
+            "created_timestamp": "1542113610846",
+            "message_create": {
+                "target": {
+                    "recipient_id": "123456789"
+                },
+                "sender_id": "987654321",
+                "source_app_id": "268278",
+                "message_data": {
+                    "text": "https:\/\/t.co\/SxhSwDrnGu",
+                    "entities": {
+                        "hashtags": [],
+                        "symbols": [],
+                        "user_mentions": [],
+                        "urls": [
+                            {
+                                "url": "https:\/\/t.co\/SxhSwDrnGu",
+                                "expanded_url": "https:\/\/twitter.com\/fooman\/status\/1042411246337884160",
+                                "display_url": "twitter.com\/fooman\u2026",
+                                "indices": [0,23]
+                            }
+                        ]
+                    }
+                }
+            }
+        }    
+    ],
+    "apps": {
+        "268278": {
+            "id": "268278",
+            "name": "Twitter Web Client",
+            "url": "http:\/\/twitter.com"
+        }
+    }
+}"""

--- a/feedback/twitter.py
+++ b/feedback/twitter.py
@@ -273,5 +273,5 @@ class TwitterHandler:
             url = direct_message.entities['urls'][0]['expanded_url']
         except (KeyError, IndexError):
             return None
-        match = re.match(r'https?://twitter.com/[a-zA-Z0-9]+/status/([0-9]*)', url)
-        return match.group(1) if match else None
+        match = re.match(r'https?://twitter.com/(\w){1,15}/status/([0-9]*)', url)
+        return match.group(2) if match else None

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,3 +5,4 @@ pytest
 pytest-cov
 pytest-django
 isort
+responses

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file requirements-dev.txt requirements-dev.in
 #
-appnope==0.1.0            # via ipython
 attrs==17.4.0             # via pytest
 coverage==4.5.1           # via pytest-cov
 decorator==4.2.1          # via ipython, traitlets
@@ -27,6 +26,7 @@ pygments==2.2.0           # via ipython
 pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest==3.4.0
+responses==0.10.4
 simplegeneric==0.8.1      # via ipython
 six==1.11.0               # via prompt-toolkit, pytest, traitlets
 traitlets==4.3.2          # via ipython


### PR DESCRIPTION
Twitter has deprecated previous API version for DMs' logic.
Sadly, current tweepy version does not work with Twitter DMs API.
We are forced to implement custom API and override necessary
parts of tweepy.

New DMs' API:
- returns both sent and recieved DMs, so we need to filter out
the ones that are sent from the bot's account.
- does not accept some DM's ID as request parameter to only
return DMS after that one, instead it returns ALL DMs for the
last 30 days
- has a new structure for the response, so we have to make heavy
changes to DirectMessage model's parsing logic.