### PR TITLE
Use extended tweet object if tweet was truncated

### DIFF
--- a/feedback/twitter.py
+++ b/feedback/twitter.py
@@ -69,7 +69,9 @@ class TwitterHandler:
 
         tweet_text = tweet.text
         if tweet.truncated:
-            tweet_text = self.twitter_api.get_status(tweet.id, tweet_mode='extended').full_text
+            # replace tweet object w/ extended tweet to properly get media info too
+            tweet = self.twitter_api.get_status(tweet.id, tweet_mode='extended')
+            tweet_text = tweet.full_text
 
         logger.debug(
             'Handling a tweet from @{}: "{}" ({})'.format(username, tweet_text, tweet.id_str)


### PR DESCRIPTION
Fetch and use full tweet object, because only it will have full
info about the tweet if it is truncated. This way we get all
entities show (media, links, tags etc)

Closes #42 