### PR TITLE
Return detailed answer on success always

### DIFF
--- a/feedback/tests/test_twitter.py
+++ b/feedback/tests/test_twitter.py
@@ -55,7 +55,9 @@ def test_handle_tweets_success(update_status, create_ticket, tweepy_search_resul
         search.assert_called_with(settings.SEARCH_STRING, rpp=100, since_id='777')
         create_ticket.assert_called_with(expected_parsed_data)
         update_status.assert_called_with(
-            'Kiitos @ViljamiTesti! Seuraa etenemistä osoitteessa: http://test_OPEN311_FEEDBACK_URL?fid=7',
+            'Hei @ViljamiTesti! Olen Helsingin kaupungin palautebotti. '
+            'Välitin viestisi kaupungin asiantuntijalle ja siihen vastataan muutaman päivän kuluessa. '
+            'Seuraa etenemistä osoitteesta: http://test_OPEN311_FEEDBACK_URL?fid=7',
             in_reply_to_status_id='874885713845735424'
         )
 

--- a/feedback/twitter.py
+++ b/feedback/twitter.py
@@ -198,12 +198,9 @@ class TwitterHandler:
     @staticmethod
     def _get_feedback_answer_text(success, username, feedback_url, self_submitted):
         if success:
-            if self_submitted:
-                return 'Kiitos @{}! Seuraa etenemistä osoitteessa: {}'.format(username, feedback_url)
-            else:
-                return ('Hei @{}! Olen Helsingin kaupungin palautebotti. '
-                        'Välitin viestisi kaupungin asiantuntijalle ja siihen vastataan muutaman päivän kuluessa. '
-                        'Seuraa etenemistä osoitteesta: {}').format(username, feedback_url)
+            return ('Hei @{}! Olen Helsingin kaupungin palautebotti. '
+                    'Välitin viestisi kaupungin asiantuntijalle ja siihen vastataan muutaman päivän kuluessa. '
+                    'Seuraa etenemistä osoitteesta: {}').format(username, feedback_url)
         elif self_submitted:
             return 'Pahoittelut @{}! Palautteen tallennus epäonnistui'.format(username)
 


### PR DESCRIPTION
Always return full answer for "feedback accpeted"
tweet, no matter if it was self submitted or not.